### PR TITLE
Fixed: flexible routing for log manager using route_prefix config

### DIFF
--- a/src/LogManagerServiceProvider.php
+++ b/src/LogManagerServiceProvider.php
@@ -40,7 +40,7 @@ class LogManagerServiceProvider extends ServiceProvider
     {
         $router->group(['namespace' => 'Backpack\LogManager\app\Http\Controllers'], function ($router) {
             // Admin Interface Routes
-            Route::group(['middleware' => ['web', 'auth'], 'prefix' => 'admin'], function () {
+            Route::group(['middleware' => ['web', 'auth'], 'prefix' => config('backpack.base.route_prefix', 'admin')], function () {
                 // Logs
                 Route::get('log', 'LogController@index');
                 Route::get('log/preview/{file_name}', 'LogController@preview');

--- a/src/resources/views/log_item.blade.php
+++ b/src/resources/views/log_item.blade.php
@@ -6,8 +6,8 @@
 	    {{ trans('backpack::logmanager.log_manager') }}<small>{{ trans('backpack::logmanager.log_manager_description') }}</small>
 	  </h1>
 	  <ol class="breadcrumb">
-	    <li><a href="{{ url('admin') }}">{{ config('base.project_name') }}</a></li>
-      <li><a href="{{ url('admin/log') }}">{{ trans('backpack::logmanager.log_manager') }}</a></li>
+	    <li><a href="{{ url(config('backpack.base.route_prefix', 'admin')) }}">{{ config('base.project_name') }}</a></li>
+      <li><a href="{{ url(config('backpack.base.route_prefix', 'admin').'/log') }}">{{ trans('backpack::logmanager.log_manager') }}</a></li>
       <li class="active">{{ trans('backpack::logmanager.preview') }}</li>
 	  </ol>
 	</section>
@@ -15,7 +15,7 @@
 
 @section('content')
 
-  <a href="{{ url('admin/log') }}"><i class="fa fa-angle-double-left"></i> {{ trans('backpack::logmanager.back_to_all_logs') }}</a><br><br>
+  <a href="{{ url(config('backpack.base.route_prefix', 'admin').'/log') }}"><i class="fa fa-angle-double-left"></i> {{ trans('backpack::logmanager.back_to_all_logs') }}</a><br><br>
 <!-- Default box -->
   <div class="box">
     <div class="box-body">

--- a/src/resources/views/logs.blade.php
+++ b/src/resources/views/logs.blade.php
@@ -6,8 +6,8 @@
         {{ trans('backpack::logmanager.log_manager') }}<small>{{ trans('backpack::logmanager.log_manager_description') }}</small>
       </h1>
       <ol class="breadcrumb">
-        <li><a href="{{ url('admin') }}">{{ config('base.project_name') }}</a></li>
-        <li><a href="{{ url('admin/log') }}">{{ trans('backpack::logmanager.log_manager') }}</a></li>
+        <li><a href="{{ url(config('backpack.base.route_prefix', 'admin')) }}">{{ config('base.project_name') }}</a></li>
+        <li><a href="{{ url(config('backpack.base.route_prefix', 'admin').'/log') }}">{{ trans('backpack::logmanager.log_manager') }}</a></li>
         <li class="active">{{ trans('backpack::logmanager.existing_logs') }}</li>
       </ol>
     </section>
@@ -35,9 +35,9 @@
             <td>{{ \Carbon\Carbon::createFromTimeStamp($log['last_modified'])->formatLocalized('%H:%M') }}</td>
             <td class="text-right">{{ round((int)$log['file_size']/1048576, 2).' MB' }}</td>
             <td>
-                <a class="btn btn-xs btn-default" href="{{ url('admin/log/preview/'.$log['file_name']) }}"><i class="fa fa-eye"></i> {{ trans('backpack::logmanager.preview') }}</a>
-                <a class="btn btn-xs btn-default" href="{{ url('admin/log/download/'.$log['file_name']) }}"><i class="fa fa-cloud-download"></i> {{ trans('backpack::logmanager.download') }}</a>
-                <a class="btn btn-xs btn-danger" data-button-type="delete" href="{{ url('admin/log/delete/'.$log['file_name']) }}"><i class="fa fa-trash-o"></i> {{ trans('backpack::logmanager.delete') }}</a>
+                <a class="btn btn-xs btn-default" href="{{ url(config('backpack.base.route_prefix', 'admin').'/log/preview/'.$log['file_name']) }}"><i class="fa fa-eye"></i> {{ trans('backpack::logmanager.preview') }}</a>
+                <a class="btn btn-xs btn-default" href="{{ url(config('backpack.base.route_prefix', 'admin').'/log/download/'.$log['file_name']) }}"><i class="fa fa-cloud-download"></i> {{ trans('backpack::logmanager.download') }}</a>
+                <a class="btn btn-xs btn-danger" data-button-type="delete" href="{{ url(config('backpack.base.route_prefix', 'admin').'/log/delete/'.$log['file_name']) }}"><i class="fa fa-trash-o"></i> {{ trans('backpack::logmanager.delete') }}</a>
             </td>
           </tr>
           @endforeach


### PR DESCRIPTION
Fixes #5 
If `route_prefix` is changed in the `backpack.base` config file, the change will now be respected by log manager.
