### PR TITLE
Order file list by default by modification date

### DIFF
--- a/src/app/Classes/LogViewer.php
+++ b/src/app/Classes/LogViewer.php
@@ -184,10 +184,11 @@ class LogViewer
 
     /**
      * @param bool $basename
+     * @param bool $sort_by_date Most recently modified files first
      *
      * @return array
      */
-    public static function getFiles($basename = false)
+    public static function getFiles($basename = false, $sort_by_date = false)
     {
         $files = glob(storage_path().'/logs/*.log');
         $files = array_reverse($files);
@@ -205,6 +206,12 @@ class LogViewer
                         'last_modified' => $disk->lastModified('storage/logs/'.$file_name),
                     ];
                 }
+            }
+
+            if($sort_by_date){
+                usort($files, function($a, $b) {
+                    return $b['last_modified'] - $a['last_modified'];
+                });
             }
         }
 

--- a/src/app/Http/Controllers/LogController.php
+++ b/src/app/Http/Controllers/LogController.php
@@ -14,7 +14,7 @@ class LogController extends Controller
      */
     public function index()
     {
-        $this->data['files'] = LogViewer::getFiles(true);
+        $this->data['files'] = LogViewer::getFiles(true, true);
         $this->data['title'] = trans('backpack::logmanager.log_manager');
 
         return view('logmanager::logs', $this->data);


### PR DESCRIPTION
*This probably is missing a config value to define the order of the files (by name, date etc.).*

If you have logs with different name roots, the default order doesn't work well as the most recent. 

For example:

**component-C-2018-06-21.log**
component-C-2018-06-20.log
component-C-2018-06-19.log
component-C-2018-06-18.log
....
component-C-2018-05-15.log
**component-B-2018-06-21.log**
component-B-2018-06-20.log
component-B-2018-06-19.log
component-B-2018-06-18.log
....
component-B-2018-05-15.log
**component-A-2018-06-21.log**
component-A-2018-06-20.log
....
