### PR TITLE
Remove unneaded line breaks of stacktrace

### DIFF
--- a/src/resources/views/log_item.blade.php
+++ b/src/resources/views/log_item.blade.php
@@ -31,9 +31,7 @@
         <div id="collapse{{ $key }}" class="panel-collapse collapse p-3" role="tabpanel" aria-labelledby="heading{{ $key }}">
           <div class="panel-body">
             <p>{{$log['text']}}</p>
-            <pre><code class="php">
-              {{ trim($log['stack']) }}
-            </code></pre>
+            <pre><code class="php">{{ trim($log['stack']) }}</code></pre>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

There were unnecessary line breaks and spaces in stack trace:

![image](https://user-images.githubusercontent.com/5526334/160007921-60db5da0-9064-476b-b4b5-4786fbb62c3b.png)

### AFTER - What is happening after this PR?

The line breaks and spaces are removed:

![image](https://user-images.githubusercontent.com/5526334/160008096-f8d7b2f7-dfe4-4b84-a9c6-5e1425f638dd.png)


## HOW

### How did you achieve that, in technical terms?

Remove spaces and line breaks in "code"-tag.



### Is it a breaking change or non-breaking change?

non-breaking, just a little view detail


### How can we test the before & after?

1. Open log file in LogManager.
2. Klick on a log entry. 
