### PR TITLE
[Minor-Bug] Replace deprecated method formatLocalized()

### DIFF
--- a/src/config/backpack/logmanager.php
+++ b/src/config/backpack/logmanager.php
@@ -10,4 +10,7 @@ return [
 
     'allow_delete' => true,
 
+    // when false the `backpack.base.default_date_format` will be used.
+    // alternatively provide your custom format
+    'date_format' => false,
 ];

--- a/src/resources/views/logs.blade.php
+++ b/src/resources/views/logs.blade.php
@@ -36,8 +36,8 @@
           <tr>
             <th scope="row">{{ $key + 1 }}</th>
             <td>{{ $file['file_name'] }}</td>
-            <td>{{ \Carbon\Carbon::createFromTimeStamp($file['last_modified'])->formatLocalized('%d %B %Y') }}</td>
-            <td>{{ \Carbon\Carbon::createFromTimeStamp($file['last_modified'])->formatLocalized('%H:%M') }}</td>
+            <td>{{ \Carbon\Carbon::createFromTimeStamp($file['last_modified'])->isoFormat(config('backpack.base.default_date_format')) }}</td>
+            <td>{{ \Carbon\Carbon::createFromTimeStamp($file['last_modified'])->isoFormat('HH:mm') }}</td>
             <td class="text-right">{{ round((int)$file['file_size']/1048576, 2).' MB' }}</td>
             <td>
                 <a class="btn btn-sm btn-link" href="{{ url(config('backpack.base.route_prefix', 'admin').'/log/preview/'. encrypt($file['file_name'])) }}"><i class="la la-eye"></i> {{ trans('backpack::logmanager.preview') }}</a>

--- a/src/resources/views/logs.blade.php
+++ b/src/resources/views/logs.blade.php
@@ -36,7 +36,7 @@
           <tr>
             <th scope="row">{{ $key + 1 }}</th>
             <td>{{ $file['file_name'] }}</td>
-            <td>{{ \Carbon\Carbon::createFromTimeStamp($file['last_modified'])->isoFormat(config('backpack.base.default_date_format')) }}</td>
+            <td>{{ \Carbon\Carbon::createFromTimeStamp($file['last_modified'])->isoFormat(config('backpack.logmanager.date_format') ?: config('backpack.base.default_date_format')) }}</td>
             <td>{{ \Carbon\Carbon::createFromTimeStamp($file['last_modified'])->isoFormat('HH:mm') }}</td>
             <td class="text-right">{{ round((int)$file['file_size']/1048576, 2).' MB' }}</td>
             <td>


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

Some users see logger entries created due to the use of the deprecated method `formatLocalized()`.
[Issue reported here](https://github.com/Laravel-Backpack/LogManager/issues/54)

### AFTER - What is happening after this PR?

No more logger entries will be created.


## HOW

### How did you achieve that, in technical terms?

Method `formatLocalized()` is replaced with `isoFormat()`.


### Is it a breaking change or non-breaking change?

Non-breaking.


### How can we test the before & after?

Just created couple of errors and checked them on Log Manager.
