### PR TITLE
Using named routing instead of hardcode

### DIFF
--- a/src/resources/views/log_item.blade.php
+++ b/src/resources/views/log_item.blade.php
@@ -3,7 +3,7 @@
 @php
   $breadcrumbs = [
     trans('backpack::crud.admin') => backpack_url('dashboard'),
-    trans('backpack::logmanager.log_manager') => backpack_url('log'),
+    trans('backpack::logmanager.log_manager') => route('log.index'),
     trans('backpack::logmanager.preview') => false,
   ];
 @endphp
@@ -12,7 +12,7 @@
     <section class="container-fluid">
       <h2>
         {{ trans('backpack::logmanager.log_manager') }}<small>{{ trans('backpack::logmanager.file_name') }}: <i>{{ $file_name }}</i></small>
-        <small><a href="{{ backpack_url('log') }}" class="hidden-print font-sm"><i class="la la-angle-double-left"></i> {{ trans('backpack::logmanager.back_to_all_logs') }}</a></small>
+        <small><a href="{{ route('log.index') }}" class="hidden-print font-sm"><i class="la la-angle-double-left"></i> {{ trans('backpack::logmanager.back_to_all_logs') }}</a></small>
       </h2>
     </section>
 @endsection

--- a/src/resources/views/logs.blade.php
+++ b/src/resources/views/logs.blade.php
@@ -3,7 +3,7 @@
 @php
   $breadcrumbs = [
     trans('backpack::crud.admin') => backpack_url('dashboard'),
-    trans('backpack::logmanager.log_manager') => backpack_url('log'),
+    trans('backpack::logmanager.log_manager') => route('log.index'),
     trans('backpack::logmanager.existing_logs') => false,
   ];
 @endphp
@@ -40,10 +40,10 @@
             <td>{{ \Carbon\Carbon::createFromTimeStamp($file['last_modified'])->isoFormat('HH:mm') }}</td>
             <td class="text-right">{{ round((int)$file['file_size']/1048576, 2).' MB' }}</td>
             <td>
-                <a class="btn btn-sm btn-link" href="{{ url(config('backpack.base.route_prefix', 'admin').'/log/preview/'. encrypt($file['file_name'])) }}"><i class="la la-eye"></i> {{ trans('backpack::logmanager.preview') }}</a>
-                <a class="btn btn-sm btn-link" href="{{ url(config('backpack.base.route_prefix', 'admin').'/log/download/'.encrypt($file['file_name'])) }}"><i class="la la-cloud-download"></i> {{ trans('backpack::logmanager.download') }}</a>
+                <a class="btn btn-sm btn-link" href="{{ route('log.show', encrypt($file['file_name'])) }}"><i class="la la-eye"></i> {{ trans('backpack::logmanager.preview') }}</a>
+                <a class="btn btn-sm btn-link" href="{{ route('log.download', encrypt($file['file_name'])) }}"><i class="la la-cloud-download"></i> {{ trans('backpack::logmanager.download') }}</a>
                 @if (config('backpack.logmanager.allow_delete'))
-                    <a class="btn btn-sm btn-link" data-button-type="delete" href="{{ url(config('backpack.base.route_prefix', 'admin').'/log/delete/'.encrypt($file['file_name'])) }}"><i class="la la-trash-o"></i> {{ trans('backpack::logmanager.delete') }}</a>
+                    <a class="btn btn-sm btn-link" data-button-type="delete" href="{{ route('log.destroy', encrypt($file['file_name'])) }}"><i class="la la-trash-o"></i> {{ trans('backpack::logmanager.delete') }}</a>
                 @endif
             </td>
           </tr>


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

The LogManager supports routing overlays, it provides named routings, but the templates use hardcode rather than named routings, making routing customization difficult.

### AFTER - What is happening after this PR?

Routing customization is simplified. It will be enough to copy and configure only one file:  `routes/backpack/logmanager.php`
