### PR TITLE
[Feature] Scroll and Open specific log entry

### DIFF
--- a/src/resources/views/log_item.blade.php
+++ b/src/resources/views/log_item.blade.php
@@ -6,6 +6,7 @@
     trans('backpack::logmanager.log_manager') => route('log.index'),
     trans('backpack::logmanager.preview') => false,
   ];
+  $sizeLog = count($logs);
 @endphp
 
 @section('header')
@@ -21,14 +22,14 @@
   <div id="accordion" role="tablist" aria-multiselectable="true">
     @forelse($logs as $key => $log)
       <div class="card mb-0 pb-0">
-        <div class="card-header bg-{{ $log['level_class'] }}" role="tab" id="heading{{ $key }}">
-            <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse{{ $key }}" aria-expanded="true" aria-controls="collapse{{ $key }}" class="text-white">
+        <div class="card-header bg-{{ $log['level_class'] }}" role="tab" id="heading{{ $sizeLog - $key }}">
+            <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse{{ $sizeLog - $key }}" aria-expanded="true" aria-controls="collapse{{ $sizeLog - $key }}" class="text-white">
               <i class="la la-{{ $log['level_img'] }}"></i>
               <span>[{{ $log['date'] }}]</span>
               {{ Str::limit($log['text'], 150) }}
             </a>
         </div>
-        <div id="collapse{{ $key }}" class="panel-collapse collapse p-3" role="tabpanel" aria-labelledby="heading{{ $key }}">
+        <div id="collapse{{ $sizeLog - $key }}" class="panel-collapse collapse p-3" role="tabpanel" aria-labelledby="heading{{ $sizeLog - $key }}">
           <div class="panel-body">
             <p>{{$log['text']}}</p>
             <pre><code class="php">{{ trim($log['stack']) }}</code></pre>
@@ -46,4 +47,13 @@
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.6/styles/default.min.css">
   <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.6/highlight.min.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>
+  <script type="text/javascript">
+    jQuery(document).ready(function($) {
+        // Scroll and Open, if #collapse exists
+        if (location.hash.match(/^#collapse/) && $(location.hash).length > 0) {
+            $(location.hash).collapse('show');
+            $('html, body').animate({scrollTop: $(location.hash).closest('.card').offset().top}, 500);
+        }
+    });
+  </script>
 @endsection

--- a/src/resources/views/log_item.blade.php
+++ b/src/resources/views/log_item.blade.php
@@ -6,7 +6,7 @@
     trans('backpack::logmanager.log_manager') => route('log.index'),
     trans('backpack::logmanager.preview') => false,
   ];
-  $sizeLog = count($logs);
+  $entryID = count($logs);
 @endphp
 
 @section('header')
@@ -22,20 +22,21 @@
   <div id="accordion" role="tablist" aria-multiselectable="true">
     @forelse($logs as $key => $log)
       <div class="card mb-0 pb-0">
-        <div class="card-header bg-{{ $log['level_class'] }}" role="tab" id="heading{{ $sizeLog - $key }}">
-            <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse{{ $sizeLog - $key }}" aria-expanded="true" aria-controls="collapse{{ $sizeLog - $key }}" class="text-white">
+        <div class="card-header bg-{{ $log['level_class'] }}" role="tab" id="heading{{ $entryID }}">
+            <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse{{ $entryID }}" aria-expanded="true" aria-controls="collapse{{ $entryID }}" class="text-white">
               <i class="la la-{{ $log['level_img'] }}"></i>
               <span>[{{ $log['date'] }}]</span>
               {{ Str::limit($log['text'], 150) }}
             </a>
         </div>
-        <div id="collapse{{ $sizeLog - $key }}" class="panel-collapse collapse p-3" role="tabpanel" aria-labelledby="heading{{ $sizeLog - $key }}">
+        <div id="collapse{{ $entryID }}" class="panel-collapse collapse p-3" role="tabpanel" aria-labelledby="heading{{ $entryID }}">
           <div class="panel-body">
             <p>{{$log['text']}}</p>
             <pre><code class="php">{{ trim($log['stack']) }}</code></pre>
           </div>
         </div>
       </div>
+      @php($entryID--)
     @empty
       <h3 class="text-center">No Logs to display.</h3>
     @endforelse


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

It is not possible to link to a specific entry in the log file.

### AFTER - What is happening after this PR?

Now you can send a link to a specific entry in the log file to someone by mail or add it to a bug report.


## HOW

### How did you achieve that, in technical terms?

The log file output uses reverse sorting. Therefore, reverse numbering of entries in the log file was also made. Adding new entries will not break previous links.
