### PR TITLE
Fix Timezone

### DIFF
--- a/src/resources/views/logs.blade.php
+++ b/src/resources/views/logs.blade.php
@@ -40,7 +40,7 @@
             <th scope="row">{{ $key + 1 }}</th>
             <td>{{ $file['file_name'] }}</td>
             <td>{{ \Carbon\Carbon::createFromTimeStamp($file['last_modified'])->isoFormat(config('backpack.logmanager.date_format') ?: config('backpack.base.default_date_format', 'D MMM YYYY')) }}</td>
-            <td>{{ \Carbon\Carbon::createFromTimeStamp($file['last_modified'])->isoFormat('HH:mm') }}</td>
+            <td>{{ \Carbon\Carbon::createFromTimeStamp($file['last_modified'], date_default_timezone_get())->isoFormat('HH:mm') }}</td>
             <td class="text-right">{{ round((int)$file['file_size']/1048576, 2).' MB' }}</td>
             <td>
                 <a class="btn btn-sm btn-link" href="{{ route('log.show', encrypt($file['file_name'])) }}"><i class="la la-eye"></i> {{ trans('backpack::logmanager.preview') }}</a>

--- a/src/resources/views/logs.blade.php
+++ b/src/resources/views/logs.blade.php
@@ -40,7 +40,7 @@
             <th scope="row">{{ $key + 1 }}</th>
             <td>{{ $file['file_name'] }}</td>
             <td>{{ \Carbon\Carbon::createFromTimeStamp($file['last_modified'])->isoFormat(config('backpack.logmanager.date_format') ?: config('backpack.base.default_date_format', 'D MMM YYYY')) }}</td>
-            <td>{{ \Carbon\Carbon::createFromTimeStamp($file['last_modified'], date_default_timezone_get())->isoFormat('HH:mm') }}</td>
+            <td>{{ \Carbon\Carbon::createFromTimeStamp($file['last_modified'], config('app.timezone'))->isoFormat('HH:mm') }}</td>
             <td class="text-right">{{ round((int)$file['file_size']/1048576, 2).' MB' }}</td>
             <td>
                 <a class="btn btn-sm btn-link" href="{{ route('log.show', encrypt($file['file_name'])) }}"><i class="la la-eye"></i> {{ trans('backpack::logmanager.preview') }}</a>


### PR DESCRIPTION
Correct timezone is retrieved.

## WHY

### BEFORE - What was wrong? What was happening before this PR?

isoFormat did not take user's timezone into account.

### AFTER - What is happening after this PR?

Correct hours and minutes are shown.

## HOW

### How did you achieve that, in technical terms?

Adding date_default_timezone_get() as second parameter for createFromTimeStamp() function.

### Is it a breaking change or non-breaking change?

Non-breaking change.

### How can we test the before & after?

Check if hours and minutes are shown correctly.