### PR TITLE
work with logs that dont have the level structure

### DIFF
--- a/src/app/Classes/LogViewer.php
+++ b/src/app/Classes/LogViewer.php
@@ -179,6 +179,25 @@ class LogViewer
             }
         }
 
+        if (empty($log)) {
+            $lines = preg_split('/\r\n|\r|\n/', $file);
+
+            foreach ($lines as $line) {
+                if (!empty(trim($line))) {
+                    $log[] = [
+                        'context'     => null,
+                        'level'       => 'info',
+                        'level_class' => static::$levels_classes['info'],
+                        'level_img'   => static::$levels_imgs['info'],
+                        'date'        => null,
+                        'text'        => $line,
+                        'in_file'     => null,
+                        'stack'       => '',
+                    ];
+                }
+            }
+        }
+
         return array_reverse($log);
     }
 


### PR DESCRIPTION
fixes: #56 

Basically if your logs didn't had the error/warning etc structure, the file wouldn't parse. 

Now, if we can't identify the log level structure, we just display it as "info". 